### PR TITLE
Feature #25 clean droplet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ DEPENDENCIES
   grape!
   librarian
   nats
+  nokogiri (>= 1.4.4)
   patron
   rack
   rack-test
@@ -216,4 +217,3 @@ DEPENDENCIES
   warden-client!
   warden-protocol!
   yajl-ruby
-  nokogiri (>= 1.4.4)

--- a/dea_control
+++ b/dea_control
@@ -3,7 +3,7 @@
 function start()
 {
   cd /home/work/dea_ng/bin 
-  nohup ruby dea ../config/dea.yml &
+  nohup ruby dea ../config/dea_ng.yml &
 }
 
 function stop()

--- a/lib/dea/config.rb
+++ b/lib/dea/config.rb
@@ -14,6 +14,7 @@ module Dea
       "only_production_apps" => false,
       "crash_block_usage_ratio_threshold" => 0.8,
       "crash_inode_usage_ratio_threshold" => 0.8,
+      "clean_droplet" => true,
     }
 
     def self.schema

--- a/lib/dea/task.rb
+++ b/lib/dea/task.rb
@@ -249,10 +249,12 @@ module Dea
         request = ::Warden::Protocol::DestroyRequest.new
         request.handle = container_handle
 
-        begin
-          promise_warden_call_with_retry(:app, request).resolve
-        rescue ::EM::Warden::Client::Error => error
-          logger.warn("Error destroying container: #{error.message}")
+        if config["clean_droplet"]
+          begin
+            promise_warden_call_with_retry(:app, request).resolve
+          rescue ::EM::Warden::Client::Error => error
+            logger.warn("Error destroying container: #{error.message}")
+          end
         end
 
         # Remove container handle from attributes now that it can no longer be used


### PR DESCRIPTION
add config clean_droplet
do not clean destory droplet in warden if set false.
droplet will be clean in warden with grace_time.

新增clean_droplet配置项
如果设置为false，则不会销毁warden中的container
如果在warden中设置了grace_time，warden会自动回收无用的container
