### PR TITLE
Feature custom http port

### DIFF
--- a/lib/dea/instance.rb
+++ b/lib/dea/instance.rb
@@ -419,14 +419,20 @@ module Dea
               'container_port' => response.container_port,
               'port_info' => info
             }
+            if "true" == info['http'].to_s
+              attributes["instance_host_port"] = response.host_port
+              attributes["instance_container_port"] = response.container_port
+            end
           end
           attributes['instance_meta']['prod_ports'] = prod_ports
 
         end
 
-        response = net_in.call(nil)
-        attributes["instance_host_port"]      = response.host_port
-        attributes["instance_container_port"] = response.container_port
+        unless attributes["instance_host_port"]
+          response = net_in.call(nil)
+          attributes["instance_host_port"]      = response.host_port
+          attributes["instance_container_port"] = response.container_port
+        end
 
         response = net_in.call(nil)
         attributes["instance_console_host_port"]      = response.host_port


### PR DESCRIPTION
支持自定义的http端口
1）若droplet.yaml 中定义http端口，则container_port使用自定义的http端口，host_port采用随机端口
2）否则，container_port和host_port都使用随机端口
