### PR TITLE
Enable sshd #46

### DIFF
--- a/lib/dea/instance.rb
+++ b/lib/dea/instance.rb
@@ -457,6 +457,15 @@ module Dea
       end
     end
 
+    def promise_setup_sshd
+      log(:debug, "start sshd service")
+      Promise.new do |p|
+        script = "service sshd start"
+        promise_warden_run(:app, script, true).resolve
+        p.deliver
+      end
+    end
+
     def promise_extract_droplet
       Promise.new do |p|
         script = "cd /home/vcap/ && tar zxf #{droplet.droplet_path}"
@@ -486,6 +495,11 @@ module Dea
         info = container.info
         manifest_path = info.container_path
         @attributes['instance_meta'] = promise_read_instance_manifest(manifest_path).resolve || {}
+        if ( config['enable_sshd'] == true )
+          @attributes['instance_meta']['raw_ports'] = {} if !@attributes['instance_meta']['raw_ports']
+          log(:warn, "ignore user defined sshd port") if @attributes['instance_meta']['raw_ports']['sshd']
+	  @attributes['instance_meta']['raw_ports']['sshd']={'port' => 22, 'http' => false, 'bns' => true} 
+        end
       rescue => e
         log(:warn, "parse droplet metadata failed with exception #{e}")
         @attributes['instance_meta'] = {}
@@ -608,6 +622,7 @@ module Dea
         promise_limit_disk.resolve
         promise_limit_memory.resolve
         promise_setup_environment.resolve
+        promise_setup_sshd.resolve if ( config['enable_sshd'] == true )
 
         p.deliver
       end
@@ -799,7 +814,6 @@ module Dea
           hc.errback  { p.deliver(false) }
 
           if attributes["debug"] != "suspend"
-            #hc.timeout(60)
             hc.timeout(timeout)
           end
         end
@@ -816,7 +830,6 @@ module Dea
           hc.errback { p.deliver(false) }
 
           if attributes["debug"] != "suspend"
-            #hc.timeout(60 * 5)
             hc.timeout(timeout)
           end
         end
@@ -853,10 +866,8 @@ module Dea
           end
           if manifest && manifest["state_file"]
             manifest_path = container_relative_path(info.container_path, manifest["state_file"])
-            #p.deliver(promise_state_file_ready(manifest_path).resolve)
             p.deliver(promise_state_file_ready(manifest_path,start_timeout).resolve)
           elsif !application_uris.empty?
-            #p.deliver(promise_port_open(instance_host_port).resolve)
             p.deliver(promise_port_open(instance_host_port,start_timeout).resolve)
           else
             p.deliver(true)


### PR DESCRIPTION
Add config "enable_sshd":
Start sshd service when create container with config "enable_sshd" (need warden support sshd)
Bind port 22 to master server and send port info to RM.
